### PR TITLE
Added space in-between bottom of form and footer

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -81,6 +81,8 @@
 
             </div>
 		</div>
+		<br>
+		<br>
 		
 		<footer class="footer"></footer>
 


### PR DESCRIPTION
Added some space in-between the bottom of the contact form and footer.
This prevents the well that holds the form from going inside the footer on small screens.